### PR TITLE
fix for roulette working backwards

### DIFF
--- a/gs_roulette.c
+++ b/gs_roulette.c
@@ -64,7 +64,7 @@ static void command_roulette(sourceinfo_t *si, int parc, char *parv[])
 	};
 
 	srand(time(NULL));
-	gs_command_report(si, "%s", roulette_responses[rand() % 6 == 0]);
+	gs_command_report(si, "%s", roulette_responses[rand() % 6 != 0]);
 }
 
 /* vim:cinoptions=>s,e0,n0,f0,{0,}0,^0,=s,ps,t0,c3,+s,(2s,us,)20,*30,gs,hs


### PR DESCRIPTION
Roulette returned 1 (_CLICK_) only one time out of 6 and other 5 were 0 (_BANG_). Correct behavior should be the opposite.
