### PR TITLE
Fix backwards game logic

### DIFF
--- a/gs_roulette.c
+++ b/gs_roulette.c
@@ -59,8 +59,8 @@ static void gs_command_report(sourceinfo_t *si, const char *fmt, ...)
 static void command_roulette(sourceinfo_t *si, int parc, char *parv[])
 {
 	static const char *roulette_responses[2] = {
-		N_("*BANG*"),
-		N_("*CLICK*")
+		N_("*CLICK*"),
+		N_("*BANG*")
 	};
 
 	srand(time(NULL));


### PR DESCRIPTION
The way it was previously setup, it would kill most of the time because "click" would only be selected in 1/6 cases (when rand() % 6 == 0). As the game was originally written, there is only one bullet not five in the barrel.