### PR TITLE
cs_regmode: Set +r if a registered channel is being recreated

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Responds to users that ping ChanServ with "Pong!".
 #### cs_regmode.c
 
 Sets the stupid, pointless DALNet-style +/-r mode when a channel
-is registered or dropped. NOT RECOMMENDED TO USE.
+is registered, recreated, or dropped. NOT RECOMMENDED TO USE.
 
 #### cs_regnotice.c
 

--- a/cs_regmode.c
+++ b/cs_regmode.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2011 William Pitcock <nenolod@atheme.org>
  * Rights to this code are as documented in doc/LICENSE.
  *
- * Set/unset DALnet channel mode +r on registration/deregistration.
+ * Set/unset DALnet channel mode +r on registration/recreation/deregistration.
  */
 
 #include "atheme-compat.h"
@@ -24,6 +24,16 @@ static void register_hook(hook_channel_req_t *hdata)
 	modestack_mode_simple(chansvs.nick, mc->chan, MTYPE_ADD, CMODE_CHANREG);
 }
 
+static void add_hook(channel_t *c)
+{
+	mychan_t *mc;
+
+	if (!(mc = mychan_find(c->name)))
+		return;
+
+	modestack_mode_simple(chansvs.nick, mc->chan, MTYPE_ADD, CMODE_CHANREG);
+}
+
 static void drop_hook(mychan_t *mc)
 {
 	if (mc == NULL || mc->chan == NULL)
@@ -38,6 +48,9 @@ _modinit(module_t *m)
 	hook_add_event("channel_register");
 	hook_add_channel_register(register_hook);
 
+	hook_add_event("channel_add");
+	hook_add_channel_add(add_hook);
+
 	hook_add_event("channel_drop");
 	hook_add_channel_drop(drop_hook);
 }
@@ -46,5 +59,6 @@ void
 _moddeinit(module_unload_intent_t intent)
 {
 	hook_del_channel_register(register_hook);
+	hook_del_channel_add(add_hook);
 	hook_del_channel_drop(drop_hook);
 }


### PR DESCRIPTION
Set +r if a registered channel is being recreated (e.g. when the last user had previously left, and then someone rejoins the channel).

Resolves what appears to be a simple oversight in cs_regmode: in this scenario, registered channels that previously had +r set would lose +r if the channel was ever recreated.