### PR TITLE
broader kill line with custom timeout

### DIFF
--- a/os_klinechan.c
+++ b/os_klinechan.c
@@ -4,7 +4,7 @@
  *
  * Autokline channels.
  *
- * Default AKILL Time: 24 Hours (86400 seconds)
+ * Default AKILL Time is based on the value of SET KLINETIME.
  */
 
 #include "atheme-compat.h"
@@ -57,7 +57,7 @@ klinechan_check_join(hook_channel_joinpart_t *hdata)
 					cu->user->user, cu->user->host,
 					cu->chan->name);
 
-			k = kline_add(cu->user->user, khost, reason, 86400, "*");
+			k = kline_add("*", khost, reason, config_options.kline_time, "*");
 			cu->user->flags |= UF_KLINESENT;
 		}
 	}
@@ -195,7 +195,7 @@ os_cmd_listklinechans(sourceinfo_t *si, int parc, char *parv[])
 
 static command_t os_klinechan = {
 	.name           = "KLINECHAN",
-	.desc           = N_("Klines all users joining a channel."),
+	.desc           = N_("Klines all users joining a channel for the duration set by SET KLINETIME."),
 	.access         = PRIV_MASS_AKILL,
 	.maxparc        = 3,
 	.cmd            = &os_cmd_klinechan,


### PR DESCRIPTION
The `os_klinechan.c` module is quite handy to deal with bad users, but
it is a little specific in the way it works. It bans the full
user@host hostmask and does so for a single day. For prolonged
botnet attacks, this is not very practical.

This patch broadens the banned hostmask to cover *all* users on the
attacker's IP address, so that rotating the username is not sufficient
to bypass the ban. This means more possible collateral damage, but I
think it's a good tradeoff considering we use this module to deal with
botnet attacks, for which we ban whole networks anyways.

Also, the timeout was hardcoded to one day. That seems awfully short
when dealing with prolonged attacks. Instead of hardcoding another
value, let's reuse the value from `SET KLINETIME` so that opers can
actually customize that setting.