### PR TITLE
os_klinechan: Make warning similar to entrymsgs

### DIFF
--- a/os_klinechan.c
+++ b/os_klinechan.c
@@ -38,7 +38,7 @@ klinechan_check_join(hook_channel_joinpart_t *hdata)
 		khost = cu->user->ip ? cu->user->ip : cu->user->host;
 		if (has_priv_user(cu->user, PRIV_JOIN_STAFFONLY))
 			notice(svs->me->nick, cu->user->nick,
-					"Warning: %s klines normal users",
+					"[%s] Warning: This channel klines normal users",
 					cu->chan->name);
 		else if (is_autokline_exempt(cu->user))
 		{


### PR DESCRIPTION
ChanServ entrymsgs are formatted like "[#channel] message". This change
changes os_klinechan to have its warning notice conform to the same
format. As a result, IRC clients are able to display the warning notice
in the affected channel.