### PR TITLE
don't block users logging in as themself

### DIFF
--- a/src/sasl_blacklist.c
+++ b/src/sasl_blacklist.c
@@ -161,6 +161,10 @@ blacklist_can_login(hook_user_login_check_t *const restrict c)
 	if (! c->si)
 		return;
 
+	if (c->si->smu == c->mu)
+		// user is attempting to log in to what they're already logged in to, no need to refuse
+		return;
+
 	if (c->si->service == saslsvs)
 	{
 		const struct sasl_sourceinfo *const ssi = (struct sasl_sourceinfo *) c->si;


### PR DESCRIPTION
done purely to quell this log line:

```
<@OperServ> asd denied login to asd (restricted address)
```

which was caused in a scenario on Libera Chat where a Tor user had connected just fine using SASL EXTERNAL, but their client was still set to send `/msg nickserv identify ...` upon connect.

that said, aside from fixing the needless log line, this change in behaviour seems correct to me